### PR TITLE
Error fix in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ pip install -r requirements.txt
 6. Copy `0firstrun.py` to `models/`
 
     ```
-    $ cd applications/stopstalk
+    $ cd stopstalk/
     $ cp models/0firstrun.py.sample models/0firstrun.py
     ```
 7. Open `0firstrun.py` and change the settings.


### PR DESCRIPTION
Since we are already in applications directory after running
```
$ cd applications/stopstalk
$ cp models/0firstrun.py.sample models/0firstrun.py
```
 we don't need to change directory to application/stopstalk , we should just do 
 
```
$ cd stopstalk
```