### PR TITLE
Updated Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ pip install -r requirements.txt --proxy=<proxy address>
 
     ```
     $ cd web2py
-    $ python web2py.py -a yourPassword // Choose any password
+    $ python2 web2py.py -a yourPassword // Choose any password
     ```
-
+    Note: web2py is not compatible with Python 3
 10. Open the browser and go to the URL -
 
     `http://localhost:8000/stopstalk/`


### PR DESCRIPTION
If the default version of python is 3, it gives an error "ModuleNotFoundError: No module named 'globals'
". Hence python2 should be used with web2py